### PR TITLE
Improve split orders

### DIFF
--- a/medusa-marketplace-demo/src/subscribers/order-placed.ts
+++ b/medusa-marketplace-demo/src/subscribers/order-placed.ts
@@ -100,7 +100,7 @@ export default async function orderPlacedHandler({
           ...sm,
           id: undefined,
         })),
-        metadata: { parentOrderId: order.id, transactionHash: "123" },
+        // metadata: {  },
       });
 
       // copy payment
@@ -125,9 +125,10 @@ export default async function orderPlacedHandler({
         },
       });
     }
-  }
 
-  console.log(`The order ${order.id} was created`);
+    // delete origin order
+    await orderModuleService.deleteOrders(order.id);
+  }
 }
 
 // subscriber config

--- a/medusa-marketplace-demo/src/subscribers/order-placed.ts
+++ b/medusa-marketplace-demo/src/subscribers/order-placed.ts
@@ -107,9 +107,12 @@ export default async function orderPlacedHandler({
       await createOrderPaymentCollectionAutorizedWorkflow(container).run({
         input: {
           orderId: childOrder.id,
-          amount: paymentCollection.amount as number,
+          amount: paymentCollection.amount,
+          authorized_amount: paymentCollection.authorized_amount,
+          captured_amount: paymentCollection.captured_amount,
           currencyCode: paymentCollection.currency_code,
           regionId: paymentCollection.region_id,
+          status: paymentCollection.status,
         },
       });
 

--- a/medusa-marketplace-demo/src/workflows/create-order-payment-collection-autorized/index.ts
+++ b/medusa-marketplace-demo/src/workflows/create-order-payment-collection-autorized/index.ts
@@ -3,23 +3,25 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
 import { createOrderPaymentCollectionAutorizedStep } from "./steps/create-order-payment-collection-autorized";
+import {
+  BigNumberValue,
+  PaymentCollectionStatus,
+} from "@medusajs/framework/types";
 
 export type CreatePaymentCollectionAutorizedInput = {
   orderId: string;
-  amount: number;
+  amount: BigNumberValue;
+  authorized_amount?: BigNumberValue;
+  captured_amount?: BigNumberValue;
   currencyCode: string;
   regionId: string;
+  status: PaymentCollectionStatus;
 };
 
 export const createOrderPaymentCollectionAutorizedWorkflow = createWorkflow(
   "create-order-payment-collection-autorized",
   (input: CreatePaymentCollectionAutorizedInput) => {
-    const paymentCollection = createOrderPaymentCollectionAutorizedStep({
-      order_id: input.orderId,
-      amount: input.amount,
-      regionId: input.regionId,
-      currencyCode: input.currencyCode,
-    });
+    const paymentCollection = createOrderPaymentCollectionAutorizedStep(input);
     return new WorkflowResponse(paymentCollection);
   }
 );

--- a/medusa-marketplace-demo/src/workflows/create-order-payment-collection-autorized/steps/create-order-payment-collection-autorized.ts
+++ b/medusa-marketplace-demo/src/workflows/create-order-payment-collection-autorized/steps/create-order-payment-collection-autorized.ts
@@ -10,8 +10,6 @@ export const createOrderPaymentCollectionAutorizedStep = createStep(
       Modules.PAYMENT
     );
 
-    console.log("input.status", input.status);
-
     // create payment
     const paymentCollections =
       await paymentModuleService.createPaymentCollections([

--- a/medusa-marketplace-demo/src/workflows/create-order-payment-collection-autorized/steps/create-order-payment-collection-autorized.ts
+++ b/medusa-marketplace-demo/src/workflows/create-order-payment-collection-autorized/steps/create-order-payment-collection-autorized.ts
@@ -1,24 +1,16 @@
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk";
-import {
-  ContainerRegistrationKeys,
-  Modules,
-  PaymentCollectionStatus,
-} from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils";
 import { IPaymentModuleService } from "@medusajs/framework/types";
-
-export type CreateOrderPaymentCollectionAutorizedInput = {
-  order_id: string;
-  amount: number;
-  currencyCode: string;
-  regionId: string;
-};
+import { CreatePaymentCollectionAutorizedInput } from "..";
 
 export const createOrderPaymentCollectionAutorizedStep = createStep(
   "create-order-payment-collection-autorized-step",
-  async (input: CreateOrderPaymentCollectionAutorizedInput, { container }) => {
+  async (input: CreatePaymentCollectionAutorizedInput, { container }) => {
     const paymentModuleService = container.resolve<IPaymentModuleService>(
       Modules.PAYMENT
     );
+
+    console.log("input.status", input.status);
 
     // create payment
     const paymentCollections =
@@ -27,9 +19,9 @@ export const createOrderPaymentCollectionAutorizedStep = createStep(
           region_id: input.regionId,
           currency_code: input.currencyCode,
           amount: input.amount,
-          status: PaymentCollectionStatus.AUTHORIZED,
-          authorized_amount: input.amount,
-          captured_amount: input.amount,
+          status: input.status,
+          authorized_amount: input.authorized_amount,
+          captured_amount: input.captured_amount,
         } as any,
       ]);
     const paymentCollectionId = paymentCollections[0].id;
@@ -38,7 +30,7 @@ export const createOrderPaymentCollectionAutorizedStep = createStep(
     const remoteLink = container.resolve(ContainerRegistrationKeys.REMOTE_LINK);
     await remoteLink.create({
       [Modules.ORDER]: {
-        order_id: input.order_id,
+        order_id: input.orderId,
       },
       [Modules.PAYMENT]: {
         payment_collection_id: paymentCollectionId,
@@ -47,7 +39,7 @@ export const createOrderPaymentCollectionAutorizedStep = createStep(
 
     return new StepResponse(paymentCollections[0], {
       paymentCollectionId,
-      orderId: input.order_id,
+      orderId: input.orderId,
     });
   },
   async ({ paymentCollectionId, orderId }, { container }) => {


### PR DESCRIPTION
- preserve payment status on child orders
- do not create child orders if products from single vendor in order
- remove origin order after child orders created